### PR TITLE
Add Dockerfile for self hosting

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -6,14 +6,9 @@
 
 DATABASE_URL="postgresql://user:pass@post.gres.com:25060/defaultdb?sslmode=require"
 
-AWS_ENDPOINT=
-AWS_ACCESS_KEY_ID=
-AWS_SECRET_KEY=
-BUCKET_BASEURL=
-BUCKET_NAME=
-
-# GitHub OAuth
-GITHUB_ID=
-GITHUB_SECRET=
-NEXTAUTH_URL=http://localhost:3000/api/auth
 SECRET=IamAVeryLongAndSuperComplexSecretNobodyWillEverFindOut
+
+# FusionAuth
+FUSIONAUTH_DOMAIN=
+FUSIONAUTH_CLIENT_ID=
+FUSIONAUTH_SECRET=

--- a/Dockerfile
+++ b/Dockerfile
@@ -28,7 +28,7 @@ RUN addgroup -g 1001 -S nodejs
 RUN adduser -S nextjs -u 1001
 
 # You only need to copy next.config.js if you are NOT using the default configuration
-# COPY --from=builder /app/next.config.js ./
+COPY --from=builder /app/next.config.js ./
 COPY --from=builder /app/public ./public
 COPY --from=builder --chown=nextjs:nodejs /app/.next ./.next
 COPY --from=builder /app/node_modules ./node_modules
@@ -39,9 +39,7 @@ USER nextjs
 
 EXPOSE 3000
 
-# Next.js collects completely anonymous telemetry data about general usage.
 # Learn more here: https://nextjs.org/telemetry
-# Uncomment the following line in case you want to disable telemetry.
 ENV NEXT_TELEMETRY_DISABLED 1
 
 CMD ["yarn", "start"]


### PR DESCRIPTION
Added a Dockerfile for self hosting the nextjs app.
But it´s not the best one yet. Final image is super big (1.5GB) and it is using multi-stage builds.
Second thing: Dockerfile copies your .env file to the image

Maybe we have to think about some tweaks for it.